### PR TITLE
Fixing bug The "policy" option does not exist when call php artisan make

### DIFF
--- a/src/Commands/ModelMakeCommand.php
+++ b/src/Commands/ModelMakeCommand.php
@@ -89,6 +89,7 @@ class ModelMakeCommand extends ConsoleModelMakeCommand
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
+            ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
         ];
     }
 }


### PR DESCRIPTION
Fixing bug  The "policy" option does not exist when call php artisan make